### PR TITLE
Updated mathematica files with restrictions of r and theta

### DIFF
--- a/Simplify.cdf
+++ b/Simplify.cdf
@@ -1,32 +1,12 @@
-(* Content-type: application/vnd.wolfram.cdf.text *)
-
-(*** Wolfram CDF File ***)
-(* http://www.wolfram.com/cdf *)
-
-(* CreatedBy='Mathematica 13.3' *)
-
-(***************************************************************************)
-(*                                                                         *)
-(*                                                                         *)
-(*  Under the Wolfram FreeCDF terms of use, this file and its content are  *)
-(*  bound by the Creative Commons BY-SA Attribution-ShareAlike license.    *)
-(*                                                                         *)
-(*        For additional information concerning CDF licensing, see:        *)
-(*                                                                         *)
-(*         www.wolfram.com/cdf/adopting-cdf/licensing-options.html         *)
-(*                                                                         *)
-(*                                                                         *)
-(***************************************************************************)
-
 (*CacheID: 234*)
 (* Internal cache information:
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
-NotebookDataPosition[      1088,         20]
-NotebookDataLength[     14225,        408]
-NotebookOptionsPosition[     14438,        401]
-NotebookOutlinePosition[     14877,        418]
-CellTagsIndexPosition[     14834,        415]
+NotebookDataPosition[         0,          0]
+NotebookDataLength[     14224,        408]
+NotebookOptionsPosition[     13350,        381]
+NotebookOutlinePosition[     13789,        398]
+CellTagsIndexPosition[     13746,        395]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -404,7 +384,7 @@ WindowMargins->{{4, Automatic}, {Automatic, 4}},
 TaggingRules-><|"TryRealOnly" -> False|>,
 FrontEndVersion->"13.3 for Mac OS X ARM (64-bit) (June 3, 2023)",
 StyleDefinitions->"ReverseColor.nb",
-ExpressionUUID->"723140a6-28dd-4601-83ce-b480d0f16ff3"
+ExpressionUUID->"119ecae8-e24d-4604-bd67-c22d45a8c875"
 ]
 (* End of Notebook Content *)
 
@@ -418,15 +398,12 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[1510, 35, 9738, 279, 1049, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
-Cell[11251, 316, 1260, 32, 60, "Output",ExpressionUUID->"e350fc95-73d6-48f1-bb3c-2f8fa9ab26b6"],
-Cell[12514, 350, 986, 24, 56, "Output",ExpressionUUID->"e7f6152c-0f6b-43f8-95e4-e2542f472260"],
-Cell[13503, 376, 919, 22, 56, "Output",ExpressionUUID->"3d3cc132-e25e-44d0-b90e-eb0576177e61"]
+Cell[422, 15, 9738, 279, 1049, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
+Cell[10163, 296, 1260, 32, 60, "Output",ExpressionUUID->"e350fc95-73d6-48f1-bb3c-2f8fa9ab26b6"],
+Cell[11426, 330, 986, 24, 56, "Output",ExpressionUUID->"e7f6152c-0f6b-43f8-95e4-e2542f472260"],
+Cell[12415, 356, 919, 22, 56, "Output",ExpressionUUID->"3d3cc132-e25e-44d0-b90e-eb0576177e61"]
 }, Open  ]]
 }
 ]
 *)
 
-(* End of internal cache information *)
-
-(* NotebookSignature 8xD4ngDrrENxYAwskwNekzjc *)

--- a/Simplify.cdf
+++ b/Simplify.cdf
@@ -1,12 +1,32 @@
+(* Content-type: application/vnd.wolfram.cdf.text *)
+
+(*** Wolfram CDF File ***)
+(* http://www.wolfram.com/cdf *)
+
+(* CreatedBy='Mathematica 13.3' *)
+
+(***************************************************************************)
+(*                                                                         *)
+(*                                                                         *)
+(*  Under the Wolfram FreeCDF terms of use, this file and its content are  *)
+(*  bound by the Creative Commons BY-SA Attribution-ShareAlike license.    *)
+(*                                                                         *)
+(*        For additional information concerning CDF licensing, see:        *)
+(*                                                                         *)
+(*         www.wolfram.com/cdf/adopting-cdf/licensing-options.html         *)
+(*                                                                         *)
+(*                                                                         *)
+(***************************************************************************)
+
 (*CacheID: 234*)
 (* Internal cache information:
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
-NotebookDataPosition[         0,          0]
-NotebookDataLength[     14224,        408]
-NotebookOptionsPosition[     13350,        381]
-NotebookOutlinePosition[     13789,        398]
-CellTagsIndexPosition[     13746,        395]
+NotebookDataPosition[      1088,         20]
+NotebookDataLength[     24790,        725]
+NotebookOptionsPosition[     24139,        709]
+NotebookOutlinePosition[     24578,        726]
+CellTagsIndexPosition[     24535,        723]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -19,96 +39,174 @@ Cell[BoxData[
    RowBox[{
     RowBox[{"Formulas", " ", "for", " ", "CsNO2"}], ",", " ", 
     RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
-  "\[IndentingNewLine]", 
+  "\[IndentingNewLine]", "\[IndentingNewLine]", 
   RowBox[{
    RowBox[{"FullSimplify", "[", 
-    SqrtBox[
-     RowBox[{
-      SuperscriptBox[
-       SubscriptBox["r", "1"], "2"], "+", 
-      SuperscriptBox[
-       SubscriptBox["r", "2"], "2"], "-", 
-      RowBox[{"2", 
-       SubscriptBox["r", "1"], 
-       SubscriptBox["r", "2"], 
-       RowBox[{"Cos", "[", 
-        RowBox[{
-         FractionBox[
-          RowBox[{"\[Pi]", "-", 
-           SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
-         RowBox[{"ArcCos", "[", 
-          RowBox[{
-           FractionBox[
-            SubscriptBox["r", "2"], 
-            RowBox[{"2", 
-             SubscriptBox["r", "1"]}]], 
-           SqrtBox[
-            RowBox[{"2", "[", 
-             RowBox[{"1", "-", 
-              RowBox[{"Cos", "[", 
-               SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], 
-        "]"}]}]}]], "]"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{"FullSimplify", "[", 
     RowBox[{
-     FractionBox[
-      RowBox[{"\[Pi]", "-", 
-       SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
-     RowBox[{"ArcCos", "[", 
+     SqrtBox[
       RowBox[{
-       FractionBox[
+       SuperscriptBox[
+        SubscriptBox["r", "1"], "2"], "+", 
+       SuperscriptBox[
+        SubscriptBox["r", "2"], "2"], "-", 
+       RowBox[{"2", 
+        SubscriptBox["r", "1"], 
         SubscriptBox["r", "2"], 
-        RowBox[{"2", 
-         SubscriptBox["r", "1"]}]], 
-       SqrtBox[
-        RowBox[{"2", "[", 
-         RowBox[{"1", "-", 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], "]"}], 
+        RowBox[{"Cos", "[", 
+         RowBox[{
+          FractionBox[
+           RowBox[{"\[Pi]", "-", 
+            SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
+          RowBox[{"ArcCos", "[", 
+           RowBox[{
+            FractionBox[
+             SubscriptBox["r", "2"], 
+             RowBox[{"2", 
+              SubscriptBox["r", "1"]}]], 
+            SqrtBox[
+             RowBox[{"2", "[", 
+              RowBox[{"1", "-", 
+               RowBox[{"Cos", "[", 
+                SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], 
+         "]"}]}]}]], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
    "\[IndentingNewLine]", "\[IndentingNewLine]", 
    RowBox[{"FullSimplify", "[", 
-    RowBox[{"2", 
-     RowBox[{"ArcSin", "[", 
+    RowBox[{
+     RowBox[{
+      FractionBox[
+       RowBox[{"\[Pi]", "-", 
+        SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
+      RowBox[{"ArcCos", "[", 
+       RowBox[{
+        FractionBox[
+         SubscriptBox["r", "2"], 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"]}]], 
+        SqrtBox[
+         RowBox[{"2", "[", 
+          RowBox[{"1", "-", 
+           RowBox[{"Cos", "[", 
+            SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
+     " ", 
+     RowBox[{"Assumptions", "->", 
       RowBox[{
-       FractionBox[
-        SubscriptBox["r", "2"], 
-        RowBox[{"2", 
-         SubscriptBox["r", "1"]}]], 
-       SqrtBox[
-        RowBox[{"2", "[", 
-         RowBox[{"1", "-", 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], "]"}], 
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"2", 
+      RowBox[{"ArcSin", "[", 
+       RowBox[{
+        FractionBox[
+         SubscriptBox["r", "2"], 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"]}]], 
+        SqrtBox[
+         RowBox[{"2", "[", 
+          RowBox[{"1", "-", 
+           RowBox[{"Cos", "[", 
+            SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
+     " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
    "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
    "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
    RowBox[{"(*", 
     RowBox[{
      RowBox[{"Formulas", " ", "for", " ", "C3H"}], ",", " ", 
      RowBox[{
-     "some", " ", "of", " ", "these", " ", "can", " ", "be", " ", 
+     "All", " ", "of", " ", "these", " ", "can", " ", "be", " ", 
       "simplified"}]}], "*)"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   
-   RowBox[{"(*", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
     RowBox[{
-     RowBox[{"FullSimplify", "[", 
-      SqrtBox[
-       RowBox[{
-        SuperscriptBox[
-         SubscriptBox["r", "2"], "2"], "+", 
-        SuperscriptBox[
-         SubscriptBox["r", "3"], "2"], "-", 
-        RowBox[{"2", 
-         SubscriptBox["r", "2"], 
-         SubscriptBox["r", "3"], 
-         RowBox[{"Cos", "[", 
-          RowBox[{
-           FractionBox["\[Pi]", "2"], "+", 
-           RowBox[{"ArcCos", "[", 
-            FractionBox[
-             SubscriptBox["r", "1"], 
-             RowBox[{"2", 
-              SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+     SqrtBox[
+      RowBox[{
+       SuperscriptBox[
+        SubscriptBox["r", "2"], "2"], "+", 
+       SuperscriptBox[
+        SubscriptBox["r", "3"], "2"], "-", 
+       RowBox[{"2", 
+        SubscriptBox["r", "2"], 
+        SubscriptBox["r", "3"], 
+        RowBox[{"Cos", "[", 
+         RowBox[{
+          FractionBox["\[Pi]", "2"], "+", 
+          RowBox[{"ArcCos", "[", 
+           FractionBox[
+            SubscriptBox["r", "1"], 
+            RowBox[{"2", 
+             SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       SubscriptBox["r", "1"], 
+       RowBox[{"2", 
+        SqrtBox[
+         RowBox[{
+          SuperscriptBox[
+           SubscriptBox["r", "2"], "2"], "+", 
+          SuperscriptBox[
+           SubscriptBox["r", "3"], "2"], "-", 
+          RowBox[{"2", 
+           SubscriptBox["r", "2"], 
+           SubscriptBox["r", "3"], 
+           RowBox[{"Cos", "[", 
+            RowBox[{
+             FractionBox["\[Pi]", "2"], "+", 
+             RowBox[{"ArcCos", "[", 
+              FractionBox[
+               SubscriptBox["r", "1"], 
+               RowBox[{"2", 
+                SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], ",",
+      " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{
       RowBox[{"ArcCos", "[", 
        FractionBox[
         SubscriptBox["r", "1"], 
@@ -130,169 +228,210 @@ Cell[BoxData[
                 SubscriptBox["r", "1"], 
                 RowBox[{"2", 
                  SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-      "]"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
-      RowBox[{
-       RowBox[{"ArcCos", "[", 
-        FractionBox[
-         SubscriptBox["r", "1"], 
-         RowBox[{"2", 
-          SqrtBox[
-           RowBox[{
-            SuperscriptBox[
-             SubscriptBox["r", "2"], "2"], "+", 
-            SuperscriptBox[
-             SubscriptBox["r", "3"], "2"], "-", 
-            RowBox[{"2", 
-             SubscriptBox["r", "2"], 
-             SubscriptBox["r", "3"], 
-             RowBox[{"Cos", "[", 
-              RowBox[{
-               FractionBox["\[Pi]", "2"], "+", 
-               RowBox[{"ArcCos", "[", 
-                FractionBox[
-                 SubscriptBox["r", "1"], 
-                 RowBox[{"2", 
-                  SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-       "-", 
-       RowBox[{"ArcCos", "[", 
-        FractionBox[
-         SubscriptBox["r", "1"], 
-         RowBox[{"2", 
-          SubscriptBox["r", "2"]}]], "]"}]}], "]"}], "\[IndentingNewLine]", 
-     "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
-      RowBox[{"ArcSin", "[", 
+      "-", 
+      RowBox[{"ArcCos", "[", 
        FractionBox[
         SubscriptBox["r", "1"], 
         RowBox[{"2", 
-         SqrtBox[
-          RowBox[{
-           SuperscriptBox[
-            SubscriptBox["r", "2"], "2"], "+", 
-           SuperscriptBox[
-            SubscriptBox["r", "3"], "2"], "-", 
-           RowBox[{"2", 
-            SubscriptBox["r", "2"], 
-            SubscriptBox["r", "3"], 
-            RowBox[{"Cos", "[", 
-             RowBox[{
-              FractionBox["\[Pi]", "2"], "+", 
-              RowBox[{"ArcCos", "[", 
-               FractionBox[
-                SubscriptBox["r", "1"], 
-                RowBox[{"2", 
-                 SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-      "]"}]}], "*)"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
+         SubscriptBox["r", "2"]}]], "]"}]}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcSin", "[", 
+      FractionBox[
+       SubscriptBox["r", "1"], 
+       RowBox[{"2", 
+        SqrtBox[
+         RowBox[{
+          SuperscriptBox[
+           SubscriptBox["r", "2"], "2"], "+", 
+          SuperscriptBox[
+           SubscriptBox["r", "3"], "2"], "-", 
+          RowBox[{"2", 
+           SubscriptBox["r", "2"], 
+           SubscriptBox["r", "3"], 
+           RowBox[{"Cos", "[", 
+            RowBox[{
+             FractionBox["\[Pi]", "2"], "+", 
+             RowBox[{"ArcCos", "[", 
+              FractionBox[
+               SubscriptBox["r", "1"], 
+               RowBox[{"2", 
+                SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], ",",
+      " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
    "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
    RowBox[{"(*", 
     RowBox[{
      RowBox[{"Formulas", " ", "for", " ", "S2H2"}], ",", " ", 
      RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
    "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{"(*", 
+   RowBox[{"FullSimplify", "[", 
     RowBox[{
-     RowBox[{"FullSimplify", "[", 
-      RowBox[{"ArcCos", "[", 
-       RowBox[{
-        SubscriptBox["r", "1"], 
-        SqrtBox[
-         FractionBox[
-          RowBox[{"1", "-", 
-           RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "1"], "]"}]}], 
-          RowBox[{"2", "[", 
-           RowBox[{
-            SuperscriptBox[
-             SubscriptBox["r", "1"], "2"], "+", 
-            SuperscriptBox[
-             SubscriptBox["r", "2"], "2"], "-", 
-            RowBox[{"2", 
-             SubscriptBox["r", "1"], 
-             SubscriptBox["r", "2"], 
-             RowBox[{"Cos", "[", 
-              SubscriptBox["\[Theta]", "2"], "]"}]}]}], "]"}]]]}], "]"}], 
-      "]"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        RowBox[{
-         SubscriptBox["r", "1"], "-", 
-         RowBox[{
-          SubscriptBox["r", "2"], 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
-        SqrtBox[
-         RowBox[{
-          SuperscriptBox[
-           SubscriptBox["r", "1"], "2"], "+", 
-          SuperscriptBox[
-           SubscriptBox["r", "2"], "2"], "-", 
-          RowBox[{"2", 
-           SubscriptBox["r", "1"], 
-           SubscriptBox["r", "2"], 
-           RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        RowBox[{
-         SubscriptBox["r", "2"], "-", 
-         RowBox[{
-          SubscriptBox["r", "1"], 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
-        SqrtBox[
-         RowBox[{
-          SuperscriptBox[
-           SubscriptBox["r", "1"], "2"], "+", 
-          SuperscriptBox[
-           SubscriptBox["r", "2"], "2"], "-", 
-          RowBox[{"2", 
-           SubscriptBox["r", "1"], 
-           SubscriptBox["r", "2"], 
-           RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        RowBox[{
-         RowBox[{"Cos", "[", 
-          SubscriptBox["\[Theta]", "1"], "]"}], "-", 
-         SuperscriptBox[
-          RowBox[{"[", 
-           RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}], "]"}], "2"]}], 
-        SuperscriptBox[
-         RowBox[{"[", 
-          RowBox[{"Sin", "[", 
-           SubscriptBox["\[Theta]", "2"], "]"}], "]"}], "2"]], "]"}], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        RowBox[{
-         RowBox[{"Cos", "[", 
-          SubscriptBox["\[Theta]", "2"], "]"}], "[", 
+     RowBox[{"ArcCos", "[", 
+      RowBox[{
+       SubscriptBox["r", "1"], 
+       SqrtBox[
+        FractionBox[
          RowBox[{"1", "-", 
           RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}], 
+           SubscriptBox["\[Theta]", "1"], "]"}]}], 
+         RowBox[{"2", "[", 
+          RowBox[{
+           SuperscriptBox[
+            SubscriptBox["r", "1"], "2"], "+", 
+           SuperscriptBox[
+            SubscriptBox["r", "2"], "2"], "-", 
+           RowBox[{"2", 
+            SubscriptBox["r", "1"], 
+            SubscriptBox["r", "2"], 
+            RowBox[{"Cos", "[", 
+             SubscriptBox["\[Theta]", "2"], "]"}]}]}], "]"}]]]}], "]"}], ",", 
+     " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       RowBox[{
+        SubscriptBox["r", "1"], "-", 
         RowBox[{
-         RowBox[{"Sin", "[", 
-          SubscriptBox["\[Theta]", "2"], "]"}], 
-         RowBox[{"Sin", "[", 
-          SubscriptBox["\[Theta]", "1"], "]"}]}]], "]"}], "]"}]}], "*)"}], 
-   "\[IndentingNewLine]", "\[IndentingNewLine]"}]}]], "Input",
+         SubscriptBox["r", "2"], 
+         RowBox[{"Cos", "[", 
+          SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
+       SqrtBox[
+        RowBox[{
+         SuperscriptBox[
+          SubscriptBox["r", "1"], "2"], "+", 
+         SuperscriptBox[
+          SubscriptBox["r", "2"], "2"], "-", 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"], 
+          SubscriptBox["r", "2"], 
+          RowBox[{"Cos", "[", 
+           SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       RowBox[{
+        SubscriptBox["r", "2"], "-", 
+        RowBox[{
+         SubscriptBox["r", "1"], 
+         RowBox[{"Cos", "[", 
+          SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
+       SqrtBox[
+        RowBox[{
+         SuperscriptBox[
+          SubscriptBox["r", "1"], "2"], "+", 
+         SuperscriptBox[
+          SubscriptBox["r", "2"], "2"], "-", 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"], 
+          SubscriptBox["r", "2"], 
+          RowBox[{"Cos", "[", 
+           SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       RowBox[{
+        RowBox[{"Cos", "[", 
+         SubscriptBox["\[Theta]", "1"], "]"}], "-", 
+        RowBox[{
+         SuperscriptBox["Cos", "2"], "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}]}], 
+       RowBox[{
+        SuperscriptBox["Sin", "2"], "[", 
+        SubscriptBox["\[Theta]", "2"], "]"}]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       RowBox[{
+        RowBox[{"Cos", "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}], "[", 
+        RowBox[{"1", "-", 
+         RowBox[{"Cos", "[", 
+          SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}], 
+       RowBox[{
+        RowBox[{"Sin", "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}], 
+        RowBox[{"Sin", "[", 
+         SubscriptBox["\[Theta]", "1"], "]"}]}]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]"}]}]], "Input",
  CellChangeTimes->CompressedData["
-1:eJxTTMoPSmViYGAQAWIQfU2B92anwFtHtZLCWyD61nreJyD6mY3YWxDtIq79
-H0RzHbDh6wLSQac2i4Po7I/FNiA6JMLDAUR/mq0bCKI1Tr0MB9ECzxQiQXSD
-d0M+iF7sVVIEos+0/asG0euVtWpANOuhTY0gWiLauRlEV+WmtoPolgLP6SCa
-SfHQYhA9idFhCYhWedi4DkQ7VbOuB9EVxfe2guiaxzOOgehrutXnQPTHCKcr
-INpkQeczEN31dO8rED31EetXEH272u0biD538N0vEP1q8ac/IHpaXA1LN8g+
-QXUOEC13yIMfRHut2icIoqW2nnUH0QfWXPcH0QAVPZkE
-  "],ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
+1:eJwdzTFIAgEAhWGTBAlMbdBwCKWwMFyiIcLAu6TMhsiCjCAidEnKSoe4c1CM
+RGuI0ApagmuIsATDsTKJBilpCCODotKDhBMUahCxfA2Pb3nwq+YdZhufx+Mp
+6oMZpeg5IOEItWslC7NRUQ6yOhkHDfLuX9iU0DUH65pT53JoLzl1cNJi1MPy
+gXYcdqW+pqCEVU5Dz6jHARmTaxXebdRoGG3XuKEgGfPC1plBH6QWbX64vjyy
+B/mqJAN3GvRHsOPdewZJWhCFa87XOHR/7t/CjJZOw5KFfIS9hwEWBvMXBRj+
+EHzDF3roB6avixVYYMpVuDvrbtxET9ophG1JoxiaTi6lUBG/H4aJyNMYfIgY
+rZSUI0JC8QJU9A0sQcr+5oThXMgHrbKQH/awp1vQQPUzsDxRPYY3lbnY/++K
+5NQtHKHZrhXhH7syxkM=
+  "],
+ CellLabel->"In[1]:=",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
 
 Cell[BoxData[
  SqrtBox[
@@ -318,15 +457,10 @@ Cell[BoxData[
     SubscriptBox["r", "2"]}], "+", 
    SubsuperscriptBox["r", "2", "2"]}]]], "Output",
  CellChangeTimes->{
-  3.900985461917469*^9, 3.900985658707184*^9, {3.9009858140825872`*^9, 
-   3.900985864651655*^9}, {3.900985979471822*^9, 3.900985995188621*^9}, 
-   3.900986053646082*^9, {3.900986429279138*^9, 3.9009864511251163`*^9}, {
-   3.9009865454766073`*^9, 3.900986555540372*^9}, 3.900986659550846*^9, 
-   3.900986950989963*^9, {3.900987018449424*^9, 3.900987043640712*^9}, 
-   3.9009872247771053`*^9, {3.90098730665539*^9, 3.900987315589512*^9}, 
-   3.900987521081943*^9},
- CellLabel->
-  "Out[113]=",ExpressionUUID->"e350fc95-73d6-48f1-bb3c-2f8fa9ab26b6"],
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.9018310356312027`*^9},
+ CellLabel->"Out[1]=",ExpressionUUID->"ff9ba09f-b695-4329-813b-39b64fdefb01"],
 
 Cell[BoxData[
  RowBox[{"\[Pi]", "-", 
@@ -344,15 +478,10 @@ Cell[BoxData[
   FractionBox[
    SubscriptBox["\[Theta]", "1"], "2"]}]], "Output",
  CellChangeTimes->{
-  3.900985461917469*^9, 3.900985658707184*^9, {3.9009858140825872`*^9, 
-   3.900985864651655*^9}, {3.900985979471822*^9, 3.900985995188621*^9}, 
-   3.900986053646082*^9, {3.900986429279138*^9, 3.9009864511251163`*^9}, {
-   3.9009865454766073`*^9, 3.900986555540372*^9}, 3.900986659550846*^9, 
-   3.900986950989963*^9, {3.900987018449424*^9, 3.900987043640712*^9}, 
-   3.9009872247771053`*^9, {3.90098730665539*^9, 3.900987315589512*^9}, 
-   3.9009875210826406`*^9},
- CellLabel->
-  "Out[114]=",ExpressionUUID->"e7f6152c-0f6b-43f8-95e4-e2542f472260"],
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.9018310356502857`*^9},
+ CellLabel->"Out[2]=",ExpressionUUID->"b3152327-3695-48d8-a8de-a660756376bf"],
 
 Cell[BoxData[
  RowBox[{"2", " ", 
@@ -368,15 +497,214 @@ Cell[BoxData[
          SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]], " ", 
      SubscriptBox["r", "2"]}]], "]"}]}]], "Output",
  CellChangeTimes->{
-  3.900985461917469*^9, 3.900985658707184*^9, {3.9009858140825872`*^9, 
-   3.900985864651655*^9}, {3.900985979471822*^9, 3.900985995188621*^9}, 
-   3.900986053646082*^9, {3.900986429279138*^9, 3.9009864511251163`*^9}, {
-   3.9009865454766073`*^9, 3.900986555540372*^9}, 3.900986659550846*^9, 
-   3.900986950989963*^9, {3.900987018449424*^9, 3.900987043640712*^9}, 
-   3.9009872247771053`*^9, {3.90098730665539*^9, 3.900987315589512*^9}, 
-   3.900987521083208*^9},
- CellLabel->
-  "Out[115]=",ExpressionUUID->"3d3cc132-e25e-44d0-b90e-eb0576177e61"]
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.90183103565368*^9},
+ CellLabel->"Out[3]=",ExpressionUUID->"404e07dd-5d3a-4b8d-b246-8911672bd5cd"],
+
+Cell[BoxData[
+ SqrtBox[
+  RowBox[{
+   SubsuperscriptBox["r", "2", "2"], "+", 
+   RowBox[{
+    SqrtBox[
+     RowBox[{"4", "-", 
+      FractionBox[
+       SubsuperscriptBox["r", "1", "2"], 
+       SubsuperscriptBox["r", "2", "2"]]}]], " ", 
+    SubscriptBox["r", "2"], " ", 
+    SubscriptBox["r", "3"]}], "+", 
+   SubsuperscriptBox["r", "3", "2"]}]]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.901831035676792*^9},
+ CellLabel->"Out[4]=",ExpressionUUID->"7b84deed-011d-4be7-a28f-75041c030eca"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  FractionBox[
+   SubscriptBox["r", "1"], 
+   RowBox[{"2", " ", 
+    SqrtBox[
+     RowBox[{
+      SubsuperscriptBox["r", "2", "2"], "+", 
+      RowBox[{
+       SqrtBox[
+        RowBox[{"4", "-", 
+         FractionBox[
+          SubsuperscriptBox["r", "1", "2"], 
+          SubsuperscriptBox["r", "2", "2"]]}]], " ", 
+       SubscriptBox["r", "2"], " ", 
+       SubscriptBox["r", "3"]}], "+", 
+      SubsuperscriptBox["r", "3", "2"]}]]}]], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.9018310362758923`*^9},
+ CellLabel->"Out[5]=",ExpressionUUID->"aa30107f-76de-42c2-95cf-290bd3a02d2f"],
+
+Cell[BoxData[
+ RowBox[{
+  RowBox[{"ArcCos", "[", 
+   FractionBox[
+    SubscriptBox["r", "1"], 
+    RowBox[{"2", " ", 
+     SqrtBox[
+      RowBox[{
+       SubsuperscriptBox["r", "2", "2"], "+", 
+       RowBox[{
+        SqrtBox[
+         RowBox[{"4", "-", 
+          FractionBox[
+           SubsuperscriptBox["r", "1", "2"], 
+           SubsuperscriptBox["r", "2", "2"]]}]], " ", 
+        SubscriptBox["r", "2"], " ", 
+        SubscriptBox["r", "3"]}], "+", 
+       SubsuperscriptBox["r", "3", "2"]}]]}]], "]"}], "-", 
+  RowBox[{"ArcSec", "[", 
+   FractionBox[
+    RowBox[{"2", " ", 
+     SubscriptBox["r", "2"]}], 
+    SubscriptBox["r", "1"]], "]"}]}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.901831036801293*^9},
+ CellLabel->"Out[6]=",ExpressionUUID->"f39ff5c8-898d-4a98-8e46-e0c1353315b9"],
+
+Cell[BoxData[
+ RowBox[{"ArcSin", "[", 
+  FractionBox[
+   SubscriptBox["r", "1"], 
+   RowBox[{"2", " ", 
+    SqrtBox[
+     RowBox[{
+      SubsuperscriptBox["r", "2", "2"], "+", 
+      RowBox[{
+       SqrtBox[
+        RowBox[{"4", "-", 
+         FractionBox[
+          SubsuperscriptBox["r", "1", "2"], 
+          SubsuperscriptBox["r", "2", "2"]]}]], " ", 
+       SubscriptBox["r", "2"], " ", 
+       SubscriptBox["r", "3"]}], "+", 
+      SubsuperscriptBox["r", "3", "2"]}]]}]], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.9018310368176517`*^9},
+ CellLabel->"Out[7]=",ExpressionUUID->"4cc20d25-245c-4d6b-8ea3-d9a6e1679ad2"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  RowBox[{
+   SqrtBox[
+    FractionBox[
+     RowBox[{"1", "-", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "1"], "]"}]}], 
+     RowBox[{"2", "[", 
+      RowBox[{
+       SubsuperscriptBox["r", "1", "2"], "-", 
+       RowBox[{"2", " ", 
+        RowBox[{"Cos", "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+        SubscriptBox["r", "1"], " ", 
+        SubscriptBox["r", "2"]}], "+", 
+       SubsuperscriptBox["r", "2", "2"]}], "]"}]]], " ", 
+   SubscriptBox["r", "1"]}], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.901831036946928*^9},
+ CellLabel->"Out[8]=",ExpressionUUID->"39badd9e-f360-4fe2-9784-3aaa21867546"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  FractionBox[
+   RowBox[{
+    SubscriptBox["r", "1"], "-", 
+    RowBox[{
+     RowBox[{"Cos", "[", 
+      SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+     SubscriptBox["r", "2"]}]}], 
+   SqrtBox[
+    RowBox[{
+     SubsuperscriptBox["r", "1", "2"], "-", 
+     RowBox[{"2", " ", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+      SubscriptBox["r", "1"], " ", 
+      SubscriptBox["r", "2"]}], "+", 
+     SubsuperscriptBox["r", "2", "2"]}]]], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.901831037307987*^9},
+ CellLabel->"Out[9]=",ExpressionUUID->"b8abf394-840f-48c9-a592-d68f4d0a1252"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  FractionBox[
+   RowBox[{
+    RowBox[{
+     RowBox[{"-", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "2"], "]"}]}], " ", 
+     SubscriptBox["r", "1"]}], "+", 
+    SubscriptBox["r", "2"]}], 
+   SqrtBox[
+    RowBox[{
+     SubsuperscriptBox["r", "1", "2"], "-", 
+     RowBox[{"2", " ", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+      SubscriptBox["r", "1"], " ", 
+      SubscriptBox["r", "2"]}], "+", 
+     SubsuperscriptBox["r", "2", "2"]}]]], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.901831037691821*^9},
+ CellLabel->"Out[10]=",ExpressionUUID->"3d7a8225-fade-4d6a-938d-4e65e6f0f5d0"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  FractionBox[
+   RowBox[{
+    RowBox[{"Cos", "[", 
+     SubscriptBox["\[Theta]", "1"], "]"}], "-", 
+    RowBox[{
+     SuperscriptBox["Cos", "2"], "[", 
+     SubscriptBox["\[Theta]", "2"], "]"}]}], 
+   RowBox[{
+    SuperscriptBox["Sin", "2"], "[", 
+    SubscriptBox["\[Theta]", "2"], "]"}]], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.901831037841566*^9},
+ CellLabel->"Out[11]=",ExpressionUUID->"c13818e6-3ee7-418b-b527-493159d8b31c"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  RowBox[{
+   RowBox[{"Csc", "[", 
+    SubscriptBox["\[Theta]", "1"], "]"}], " ", 
+   RowBox[{"Csc", "[", 
+    SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+   RowBox[{
+    RowBox[{"Cos", "[", 
+     SubscriptBox["\[Theta]", "2"], "]"}], "[", 
+    RowBox[{"1", "-", 
+     RowBox[{"Cos", "[", 
+      SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]}], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9, 
+   3.901831037993593*^9},
+ CellLabel->"Out[12]=",ExpressionUUID->"a343d798-b4be-48f7-a32f-a19fff406f6f"]
 }, Open  ]]
 },
 WindowSize->{Full, Full},
@@ -384,7 +712,7 @@ WindowMargins->{{4, Automatic}, {Automatic, 4}},
 TaggingRules-><|"TryRealOnly" -> False|>,
 FrontEndVersion->"13.3 for Mac OS X ARM (64-bit) (June 3, 2023)",
 StyleDefinitions->"ReverseColor.nb",
-ExpressionUUID->"119ecae8-e24d-4604-bd67-c22d45a8c875"
+ExpressionUUID->"44c06ff2-da52-44a1-9582-983365bd4ca4"
 ]
 (* End of Notebook Content *)
 
@@ -398,12 +726,24 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[422, 15, 9738, 279, 1049, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
-Cell[10163, 296, 1260, 32, 60, "Output",ExpressionUUID->"e350fc95-73d6-48f1-bb3c-2f8fa9ab26b6"],
-Cell[11426, 330, 986, 24, 56, "Output",ExpressionUUID->"e7f6152c-0f6b-43f8-95e4-e2542f472260"],
-Cell[12415, 356, 919, 22, 56, "Output",ExpressionUUID->"3d3cc132-e25e-44d0-b90e-eb0576177e61"]
+Cell[1510, 35, 13458, 398, 1275, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
+Cell[14971, 435, 966, 27, 60, "Output",ExpressionUUID->"ff9ba09f-b695-4329-813b-39b64fdefb01"],
+Cell[15940, 464, 690, 19, 56, "Output",ExpressionUUID->"b3152327-3695-48d8-a8de-a660756376bf"],
+Cell[16633, 485, 622, 17, 56, "Output",ExpressionUUID->"404e07dd-5d3a-4b8d-b246-8911672bd5cd"],
+Cell[17258, 504, 630, 17, 68, "Output",ExpressionUUID->"7b84deed-011d-4be7-a28f-75041c030eca"],
+Cell[17891, 523, 768, 21, 77, "Output",ExpressionUUID->"aa30107f-76de-42c2-95cf-290bd3a02d2f"],
+Cell[18662, 546, 933, 27, 79, "Output",ExpressionUUID->"f39ff5c8-898d-4a98-8e46-e0c1353315b9"],
+Cell[19598, 575, 768, 21, 77, "Output",ExpressionUUID->"4cc20d25-245c-4d6b-8ea3-d9a6e1679ad2"],
+Cell[20369, 598, 825, 22, 64, "Output",ExpressionUUID->"39badd9e-f360-4fe2-9784-3aaa21867546"],
+Cell[21197, 622, 800, 22, 58, "Output",ExpressionUUID->"b8abf394-840f-48c9-a592-d68f4d0a1252"],
+Cell[22000, 646, 824, 23, 58, "Output",ExpressionUUID->"3d7a8225-fade-4d6a-938d-4e65e6f0f5d0"],
+Cell[22827, 671, 620, 16, 57, "Output",ExpressionUUID->"c13818e6-3ee7-418b-b527-493159d8b31c"],
+Cell[23450, 689, 673, 17, 57, "Output",ExpressionUUID->"a343d798-b4be-48f7-a32f-a19fff406f6f"]
 }, Open  ]]
 }
 ]
 *)
 
+(* End of internal cache information *)
+
+(* NotebookSignature YvDPlohkABPW5BKmhIp9XsyD *)

--- a/Simplify.nb
+++ b/Simplify.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     18988,        554]
-NotebookOptionsPosition[     18080,        532]
-NotebookOutlinePosition[     18519,        549]
-CellTagsIndexPosition[     18476,        546]
+NotebookDataLength[     18559,        549]
+NotebookOptionsPosition[     17651,        527]
+NotebookOutlinePosition[     18090,        544]
+CellTagsIndexPosition[     18047,        541]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -26,402 +26,397 @@ Cell[BoxData[
    RowBox[{
     RowBox[{"Formulas", " ", "for", " ", "CsNO2"}], ",", " ", 
     RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
-  "\[IndentingNewLine]", 
-  RowBox[{"(*", "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      SqrtBox[
-       RowBox[{
-        SuperscriptBox[
-         SubscriptBox["r", "1"], "2"], "+", 
-        SuperscriptBox[
-         SubscriptBox["r", "2"], "2"], "-", 
-        RowBox[{"2", 
-         SubscriptBox["r", "1"], 
-         SubscriptBox["r", "2"], 
-         RowBox[{"Cos", "[", 
-          RowBox[{
-           FractionBox[
-            RowBox[{"\[Pi]", "-", 
-             SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
-           RowBox[{"ArcCos", "[", 
-            RowBox[{
-             FractionBox[
-              SubscriptBox["r", "2"], 
-              RowBox[{"2", 
-               SubscriptBox["r", "1"]}]], 
-             SqrtBox[
-              RowBox[{"2", "[", 
-               RowBox[{"1", "-", 
-                RowBox[{"Cos", "[", 
-                 SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], 
-          "]"}]}]}]], ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
-    "\[IndentingNewLine]", "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      RowBox[{
-       FractionBox[
-        RowBox[{"\[Pi]", "-", 
-         SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
-       RowBox[{"ArcCos", "[", 
-        RowBox[{
-         FractionBox[
-          SubscriptBox["r", "2"], 
-          RowBox[{"2", 
-           SubscriptBox["r", "1"]}]], 
-         SqrtBox[
-          RowBox[{"2", "[", 
-           RowBox[{"1", "-", 
-            RowBox[{"Cos", "[", 
-             SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
-      " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
-    "\[IndentingNewLine]", "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      RowBox[{"2", 
-       RowBox[{"ArcSin", "[", 
-        RowBox[{
-         FractionBox[
-          SubscriptBox["r", "2"], 
-          RowBox[{"2", 
-           SubscriptBox["r", "1"]}]], 
-         SqrtBox[
-          RowBox[{"2", "[", 
-           RowBox[{"1", "-", 
-            RowBox[{"Cos", "[", 
-             SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
-      " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}]}], 
-   "\[IndentingNewLine]", "*)"}], "\[IndentingNewLine]", 
-  "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
   "\[IndentingNewLine]", "\[IndentingNewLine]", 
-  RowBox[{"(*", 
-   RowBox[{
-    RowBox[{"Formulas", " ", "for", " ", "C3H"}], ",", " ", 
+  RowBox[{
+   RowBox[{"FullSimplify", "[", 
     RowBox[{
-    "All", " ", "of", " ", "these", " ", "can", " ", "be", " ", 
-     "simplified"}]}], "*)"}], "\[IndentingNewLine]", 
-  RowBox[{"(*", "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      SqrtBox[
-       RowBox[{
-        SuperscriptBox[
-         SubscriptBox["r", "2"], "2"], "+", 
-        SuperscriptBox[
-         SubscriptBox["r", "3"], "2"], "-", 
-        RowBox[{"2", 
-         SubscriptBox["r", "2"], 
-         SubscriptBox["r", "3"], 
-         RowBox[{"Cos", "[", 
-          RowBox[{
-           FractionBox["\[Pi]", "2"], "+", 
-           RowBox[{"ArcCos", "[", 
-            FractionBox[
-             SubscriptBox["r", "1"], 
-             RowBox[{"2", 
-              SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]], ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
-    "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        SubscriptBox["r", "1"], 
-        RowBox[{"2", 
-         SqrtBox[
-          RowBox[{
-           SuperscriptBox[
-            SubscriptBox["r", "2"], "2"], "+", 
-           SuperscriptBox[
-            SubscriptBox["r", "3"], "2"], "-", 
-           RowBox[{"2", 
-            SubscriptBox["r", "2"], 
-            SubscriptBox["r", "3"], 
-            RowBox[{"Cos", "[", 
-             RowBox[{
-              FractionBox["\[Pi]", "2"], "+", 
-              RowBox[{"ArcCos", "[", 
-               FractionBox[
-                SubscriptBox["r", "1"], 
-                RowBox[{"2", 
-                 SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-      ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
-    "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
+     SqrtBox[
       RowBox[{
-       RowBox[{"ArcCos", "[", 
-        FractionBox[
-         SubscriptBox["r", "1"], 
-         RowBox[{"2", 
-          SqrtBox[
-           RowBox[{
-            SuperscriptBox[
-             SubscriptBox["r", "2"], "2"], "+", 
-            SuperscriptBox[
-             SubscriptBox["r", "3"], "2"], "-", 
-            RowBox[{"2", 
-             SubscriptBox["r", "2"], 
-             SubscriptBox["r", "3"], 
-             RowBox[{"Cos", "[", 
-              RowBox[{
-               FractionBox["\[Pi]", "2"], "+", 
-               RowBox[{"ArcCos", "[", 
-                FractionBox[
-                 SubscriptBox["r", "1"], 
-                 RowBox[{"2", 
-                  SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-       "-", 
-       RowBox[{"ArcCos", "[", 
-        FractionBox[
-         SubscriptBox["r", "1"], 
-         RowBox[{"2", 
-          SubscriptBox["r", "2"]}]], "]"}]}], ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
-    "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      RowBox[{"ArcSin", "[", 
-       FractionBox[
+       SuperscriptBox[
+        SubscriptBox["r", "1"], "2"], "+", 
+       SuperscriptBox[
+        SubscriptBox["r", "2"], "2"], "-", 
+       RowBox[{"2", 
         SubscriptBox["r", "1"], 
-        RowBox[{"2", 
-         SqrtBox[
-          RowBox[{
-           SuperscriptBox[
-            SubscriptBox["r", "2"], "2"], "+", 
-           SuperscriptBox[
-            SubscriptBox["r", "3"], "2"], "-", 
-           RowBox[{"2", 
-            SubscriptBox["r", "2"], 
-            SubscriptBox["r", "3"], 
-            RowBox[{"Cos", "[", 
-             RowBox[{
-              FractionBox["\[Pi]", "2"], "+", 
-              RowBox[{"ArcCos", "[", 
-               FractionBox[
-                SubscriptBox["r", "1"], 
-                RowBox[{"2", 
-                 SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-      ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}]}], 
-   "\[IndentingNewLine]", "*)"}], "\[IndentingNewLine]", 
-  "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
-  "\[IndentingNewLine]", 
-  RowBox[{"(*", 
-   RowBox[{
-    RowBox[{"Formulas", " ", "for", " ", "S2H2"}], ",", " ", 
-    RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
-  "\[IndentingNewLine]", 
-  RowBox[{"(*", "\[IndentingNewLine]", 
-   RowBox[{
-    RowBox[{"FullSimplify", "[", 
+        SubscriptBox["r", "2"], 
+        RowBox[{"Cos", "[", 
+         RowBox[{
+          FractionBox[
+           RowBox[{"\[Pi]", "-", 
+            SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
+          RowBox[{"ArcCos", "[", 
+           RowBox[{
+            FractionBox[
+             SubscriptBox["r", "2"], 
+             RowBox[{"2", 
+              SubscriptBox["r", "1"]}]], 
+            SqrtBox[
+             RowBox[{"2", "[", 
+              RowBox[{"1", "-", 
+               RowBox[{"Cos", "[", 
+                SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], 
+         "]"}]}]}]], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
      RowBox[{
+      FractionBox[
+       RowBox[{"\[Pi]", "-", 
+        SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
       RowBox[{"ArcCos", "[", 
        RowBox[{
-        SubscriptBox["r", "1"], 
+        FractionBox[
+         SubscriptBox["r", "2"], 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"]}]], 
         SqrtBox[
-         FractionBox[
+         RowBox[{"2", "[", 
           RowBox[{"1", "-", 
            RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "1"], "]"}]}], 
-          RowBox[{"2", "[", 
-           RowBox[{
-            SuperscriptBox[
-             SubscriptBox["r", "1"], "2"], "+", 
-            SuperscriptBox[
-             SubscriptBox["r", "2"], "2"], "-", 
+            SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
+     " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"2", 
+      RowBox[{"ArcSin", "[", 
+       RowBox[{
+        FractionBox[
+         SubscriptBox["r", "2"], 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"]}]], 
+        SqrtBox[
+         RowBox[{"2", "[", 
+          RowBox[{"1", "-", 
+           RowBox[{"Cos", "[", 
+            SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
+     " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"(*", 
+    RowBox[{
+     RowBox[{"Formulas", " ", "for", " ", "C3H"}], ",", " ", 
+     RowBox[{
+     "All", " ", "of", " ", "these", " ", "can", " ", "be", " ", 
+      "simplified"}]}], "*)"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     SqrtBox[
+      RowBox[{
+       SuperscriptBox[
+        SubscriptBox["r", "2"], "2"], "+", 
+       SuperscriptBox[
+        SubscriptBox["r", "3"], "2"], "-", 
+       RowBox[{"2", 
+        SubscriptBox["r", "2"], 
+        SubscriptBox["r", "3"], 
+        RowBox[{"Cos", "[", 
+         RowBox[{
+          FractionBox["\[Pi]", "2"], "+", 
+          RowBox[{"ArcCos", "[", 
+           FractionBox[
+            SubscriptBox["r", "1"], 
             RowBox[{"2", 
-             SubscriptBox["r", "1"], 
-             SubscriptBox["r", "2"], 
-             RowBox[{"Cos", "[", 
-              SubscriptBox["\[Theta]", "2"], "]"}]}]}], "]"}]]]}], "]"}], ",",
-       " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
-    "\[IndentingNewLine]", "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        RowBox[{
-         SubscriptBox["r", "1"], "-", 
-         RowBox[{
-          SubscriptBox["r", "2"], 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
+             SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       SubscriptBox["r", "1"], 
+       RowBox[{"2", 
         SqrtBox[
          RowBox[{
           SuperscriptBox[
-           SubscriptBox["r", "1"], "2"], "+", 
+           SubscriptBox["r", "2"], "2"], "+", 
           SuperscriptBox[
-           SubscriptBox["r", "2"], "2"], "-", 
+           SubscriptBox["r", "3"], "2"], "-", 
           RowBox[{"2", 
-           SubscriptBox["r", "1"], 
            SubscriptBox["r", "2"], 
+           SubscriptBox["r", "3"], 
            RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
-    "\[IndentingNewLine]", "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
+            RowBox[{
+             FractionBox["\[Pi]", "2"], "+", 
+             RowBox[{"ArcCos", "[", 
+              FractionBox[
+               SubscriptBox["r", "1"], 
+               RowBox[{"2", 
+                SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], ",",
+      " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
      RowBox[{
       RowBox[{"ArcCos", "[", 
        FractionBox[
-        RowBox[{
-         SubscriptBox["r", "2"], "-", 
-         RowBox[{
-          SubscriptBox["r", "1"], 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
+        SubscriptBox["r", "1"], 
+        RowBox[{"2", 
+         SqrtBox[
+          RowBox[{
+           SuperscriptBox[
+            SubscriptBox["r", "2"], "2"], "+", 
+           SuperscriptBox[
+            SubscriptBox["r", "3"], "2"], "-", 
+           RowBox[{"2", 
+            SubscriptBox["r", "2"], 
+            SubscriptBox["r", "3"], 
+            RowBox[{"Cos", "[", 
+             RowBox[{
+              FractionBox["\[Pi]", "2"], "+", 
+              RowBox[{"ArcCos", "[", 
+               FractionBox[
+                SubscriptBox["r", "1"], 
+                RowBox[{"2", 
+                 SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
+      "-", 
+      RowBox[{"ArcCos", "[", 
+       FractionBox[
+        SubscriptBox["r", "1"], 
+        RowBox[{"2", 
+         SubscriptBox["r", "2"]}]], "]"}]}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcSin", "[", 
+      FractionBox[
+       SubscriptBox["r", "1"], 
+       RowBox[{"2", 
         SqrtBox[
          RowBox[{
           SuperscriptBox[
-           SubscriptBox["r", "1"], "2"], "+", 
+           SubscriptBox["r", "2"], "2"], "+", 
           SuperscriptBox[
-           SubscriptBox["r", "2"], "2"], "-", 
+           SubscriptBox["r", "3"], "2"], "-", 
           RowBox[{"2", 
-           SubscriptBox["r", "1"], 
            SubscriptBox["r", "2"], 
+           SubscriptBox["r", "3"], 
            RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
-    "\[IndentingNewLine]", "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        RowBox[{
-         RowBox[{"Cos", "[", 
-          SubscriptBox["\[Theta]", "1"], "]"}], "-", 
-         RowBox[{
-          SuperscriptBox["Cos", "2"], "[", 
-          SubscriptBox["\[Theta]", "2"], "]"}]}], 
-        RowBox[{
-         SuperscriptBox["Sin", "2"], "[", 
-         SubscriptBox["\[Theta]", "2"], "]"}]], "]"}], ",", " ", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
-       RowBox[{
-        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
-    "\[IndentingNewLine]", "\[IndentingNewLine]", 
-    RowBox[{"FullSimplify", "[", 
-     RowBox[{
-      RowBox[{"ArcCos", "[", 
-       FractionBox[
-        RowBox[{
-         RowBox[{"Cos", "[", 
-          SubscriptBox["\[Theta]", "2"], "]"}], "[", 
+            RowBox[{
+             FractionBox["\[Pi]", "2"], "+", 
+             RowBox[{"ArcCos", "[", 
+              FractionBox[
+               SubscriptBox["r", "1"], 
+               RowBox[{"2", 
+                SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], ",",
+      " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"(*", 
+    RowBox[{
+     RowBox[{"Formulas", " ", "for", " ", "S2H2"}], ",", " ", 
+     RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      RowBox[{
+       SubscriptBox["r", "1"], 
+       SqrtBox[
+        FractionBox[
          RowBox[{"1", "-", 
           RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}], 
+           SubscriptBox["\[Theta]", "1"], "]"}]}], 
+         RowBox[{"2", "[", 
+          RowBox[{
+           SuperscriptBox[
+            SubscriptBox["r", "1"], "2"], "+", 
+           SuperscriptBox[
+            SubscriptBox["r", "2"], "2"], "-", 
+           RowBox[{"2", 
+            SubscriptBox["r", "1"], 
+            SubscriptBox["r", "2"], 
+            RowBox[{"Cos", "[", 
+             SubscriptBox["\[Theta]", "2"], "]"}]}]}], "]"}]]]}], "]"}], ",", 
+     " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       RowBox[{
+        SubscriptBox["r", "1"], "-", 
         RowBox[{
-         RowBox[{"Sin", "[", 
-          SubscriptBox["\[Theta]", "2"], "]"}], 
-         RowBox[{"Sin", "[", 
-          SubscriptBox["\[Theta]", "1"], "]"}]}]], "]"}], ",", " ", 
-      RowBox[{"Assumptions", "->", 
+         SubscriptBox["r", "2"], 
+         RowBox[{"Cos", "[", 
+          SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
+       SqrtBox[
+        RowBox[{
+         SuperscriptBox[
+          SubscriptBox["r", "1"], "2"], "+", 
+         SuperscriptBox[
+          SubscriptBox["r", "2"], "2"], "-", 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"], 
+          SubscriptBox["r", "2"], 
+          RowBox[{"Cos", "[", 
+           SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
        RowBox[{
-        SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
-      RowBox[{"Assumptions", "->", 
+        SubscriptBox["r", "2"], "-", 
+        RowBox[{
+         SubscriptBox["r", "1"], 
+         RowBox[{"Cos", "[", 
+          SubscriptBox["\[Theta]", "2"], "]"}]}]}], 
+       SqrtBox[
+        RowBox[{
+         SuperscriptBox[
+          SubscriptBox["r", "1"], "2"], "+", 
+         SuperscriptBox[
+          SubscriptBox["r", "2"], "2"], "-", 
+         RowBox[{"2", 
+          SubscriptBox["r", "1"], 
+          SubscriptBox["r", "2"], 
+          RowBox[{"Cos", "[", 
+           SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
        RowBox[{
-        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}]}], 
-   "\[IndentingNewLine]", "*)"}], "\[IndentingNewLine]", 
-  "\[IndentingNewLine]"}]], "Input",
+        RowBox[{"Cos", "[", 
+         SubscriptBox["\[Theta]", "1"], "]"}], "-", 
+        RowBox[{
+         SuperscriptBox["Cos", "2"], "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}]}], 
+       RowBox[{
+        SuperscriptBox["Sin", "2"], "[", 
+        SubscriptBox["\[Theta]", "2"], "]"}]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{"FullSimplify", "[", 
+    RowBox[{
+     RowBox[{"ArcCos", "[", 
+      FractionBox[
+       RowBox[{
+        RowBox[{"Cos", "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}], "[", 
+        RowBox[{"1", "-", 
+         RowBox[{"Cos", "[", 
+          SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}], 
+       RowBox[{
+        RowBox[{"Sin", "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}], 
+        RowBox[{"Sin", "[", 
+         SubscriptBox["\[Theta]", "1"], "]"}]}]], "]"}], ",", " ", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
+     RowBox[{"Assumptions", "->", 
+      RowBox[{
+       SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+   "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   "\[IndentingNewLine]"}]}]], "Input",
  CellChangeTimes->CompressedData["
-1:eJwVzUEoQwEAh/FZXi012y4bO2iLEO0iB2lqm8UzBxllUpK2i8XwdtB777A1
-WRsnvaFc1HOQxmrakeYlh8Vy0GSKMK+spvaKw1rY//D1O37GeZ/TI5fJZM21
-YM6gfIyoS9Z2/0oe5hPKAhTN2hK067r/YEPa3Bit6cyc6aC3TJnhpIu0QGnf
-NA47M59TUC0apmFgNOCDvMO/Cm82fhmYaO1iISEkg7BpZjAE6UVPGK4vj+xC
-uVHg4Xad5RC2vQZPoY0hEnCNek5B9n3vGuZMTBaWXbZ72HsQEWH047wIY2/E
-N3xihn5g9vKrAou8VIU7s2z9Jn6aDgVsEUgVdBxfaKA+dTsM0/GHMXgXJ920
-pmTlFKoFqO8bWIK094WCsQIXgm4tF4Y94skWtNP9PJQmqkfwqjKXhP+PBL5+
-
+1:eJwdzTFIAgEAhWGTBAlMbdBwCKWwMFyiIcLAu6TMhsiCjCAidEnKSoe4c1CM
+RGuI0ApagmuIsATDsTKJBilpCCODotKDhBMUahCxfA2Pb3nwq+YdZhufx+Mp
+6oMZpeg5IOEItWslC7NRUQ6yOhkHDfLuX9iU0DUH65pT53JoLzl1cNJi1MPy
+gXYcdqW+pqCEVU5Dz6jHARmTaxXebdRoGG3XuKEgGfPC1plBH6QWbX64vjyy
+B/mqJAN3GvRHsOPdewZJWhCFa87XOHR/7t/CjJZOw5KFfIS9hwEWBvMXBRj+
+EHzDF3roB6avixVYYMpVuDvrbtxET9ophG1JoxiaTi6lUBG/H4aJyNMYfIgY
+rZSUI0JC8QJU9A0sQcr+5oThXMgHrbKQH/awp1vQQPUzsDxRPYY3lbnY/++K
+5NQtHKHZrhXhH7syxkM=
   "],ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
 
 Cell[BoxData[
@@ -549,12 +544,12 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 13864, 402, 1120, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
-Cell[14447, 426, 800, 21, 64, "Output",ExpressionUUID->"112898ba-4d92-4169-93e1-9eeb98b3e397"],
-Cell[15250, 449, 773, 21, 58, "Output",ExpressionUUID->"eceefdfc-656c-4af4-b07e-5432c020b547"],
-Cell[16026, 472, 796, 22, 58, "Output",ExpressionUUID->"6cde4a8c-fe19-41f6-a4e7-f9a573e71526"],
-Cell[16825, 496, 592, 15, 57, "Output",ExpressionUUID->"33727f99-9839-441c-b2aa-2830b8e743f5"],
-Cell[17420, 513, 644, 16, 34, "Output",ExpressionUUID->"b2781ddb-056d-4e5a-8430-240d1e0ab1e7"]
+Cell[580, 22, 13435, 397, 1275, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
+Cell[14018, 421, 800, 21, 64, "Output",ExpressionUUID->"112898ba-4d92-4169-93e1-9eeb98b3e397"],
+Cell[14821, 444, 773, 21, 58, "Output",ExpressionUUID->"eceefdfc-656c-4af4-b07e-5432c020b547"],
+Cell[15597, 467, 796, 22, 58, "Output",ExpressionUUID->"6cde4a8c-fe19-41f6-a4e7-f9a573e71526"],
+Cell[16396, 491, 592, 15, 57, "Output",ExpressionUUID->"33727f99-9839-441c-b2aa-2830b8e743f5"],
+Cell[16991, 508, 644, 16, 34, "Output",ExpressionUUID->"b2781ddb-056d-4e5a-8430-240d1e0ab1e7"]
 }, Open  ]]
 }
 ]

--- a/Simplify.nb
+++ b/Simplify.nb
@@ -10,10 +10,10 @@
 NotebookFileLineBreakTest
 NotebookFileLineBreakTest
 NotebookDataPosition[       158,          7]
-NotebookDataLength[     14224,        408]
-NotebookOptionsPosition[     13508,        388]
-NotebookOutlinePosition[     13947,        405]
-CellTagsIndexPosition[     13904,        402]
+NotebookDataLength[     18988,        554]
+NotebookOptionsPosition[     18080,        532]
+NotebookOutlinePosition[     18519,        549]
+CellTagsIndexPosition[     18476,        546]
 WindowFrame->Normal*)
 
 (* Beginning of Notebook Content *)
@@ -27,76 +27,111 @@ Cell[BoxData[
     RowBox[{"Formulas", " ", "for", " ", "CsNO2"}], ",", " ", 
     RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
   "\[IndentingNewLine]", 
-  RowBox[{
-   RowBox[{"FullSimplify", "[", 
-    SqrtBox[
+  RowBox[{"(*", "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"FullSimplify", "[", 
      RowBox[{
-      SuperscriptBox[
-       SubscriptBox["r", "1"], "2"], "+", 
-      SuperscriptBox[
-       SubscriptBox["r", "2"], "2"], "-", 
-      RowBox[{"2", 
-       SubscriptBox["r", "1"], 
-       SubscriptBox["r", "2"], 
-       RowBox[{"Cos", "[", 
-        RowBox[{
-         FractionBox[
-          RowBox[{"\[Pi]", "-", 
-           SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
-         RowBox[{"ArcCos", "[", 
+      SqrtBox[
+       RowBox[{
+        SuperscriptBox[
+         SubscriptBox["r", "1"], "2"], "+", 
+        SuperscriptBox[
+         SubscriptBox["r", "2"], "2"], "-", 
+        RowBox[{"2", 
+         SubscriptBox["r", "1"], 
+         SubscriptBox["r", "2"], 
+         RowBox[{"Cos", "[", 
           RowBox[{
            FractionBox[
-            SubscriptBox["r", "2"], 
-            RowBox[{"2", 
-             SubscriptBox["r", "1"]}]], 
-           SqrtBox[
-            RowBox[{"2", "[", 
-             RowBox[{"1", "-", 
-              RowBox[{"Cos", "[", 
-               SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], 
-        "]"}]}]}]], "]"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{"FullSimplify", "[", 
-    RowBox[{
-     FractionBox[
-      RowBox[{"\[Pi]", "-", 
-       SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
-     RowBox[{"ArcCos", "[", 
-      RowBox[{
-       FractionBox[
-        SubscriptBox["r", "2"], 
-        RowBox[{"2", 
-         SubscriptBox["r", "1"]}]], 
-       SqrtBox[
-        RowBox[{"2", "[", 
-         RowBox[{"1", "-", 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], "]"}], 
-   "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{"FullSimplify", "[", 
-    RowBox[{"2", 
-     RowBox[{"ArcSin", "[", 
-      RowBox[{
-       FractionBox[
-        SubscriptBox["r", "2"], 
-        RowBox[{"2", 
-         SubscriptBox["r", "1"]}]], 
-       SqrtBox[
-        RowBox[{"2", "[", 
-         RowBox[{"1", "-", 
-          RowBox[{"Cos", "[", 
-           SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], "]"}], 
-   "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{"(*", 
-    RowBox[{
-     RowBox[{"Formulas", " ", "for", " ", "C3H"}], ",", " ", 
+            RowBox[{"\[Pi]", "-", 
+             SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
+           RowBox[{"ArcCos", "[", 
+            RowBox[{
+             FractionBox[
+              SubscriptBox["r", "2"], 
+              RowBox[{"2", 
+               SubscriptBox["r", "1"]}]], 
+             SqrtBox[
+              RowBox[{"2", "[", 
+               RowBox[{"1", "-", 
+                RowBox[{"Cos", "[", 
+                 SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], 
+          "]"}]}]}]], ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+    "\[IndentingNewLine]", "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
      RowBox[{
-     "some", " ", "of", " ", "these", " ", "can", " ", "be", " ", 
-      "simplified"}]}], "*)"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   
-   RowBox[{"(*", 
+      RowBox[{
+       FractionBox[
+        RowBox[{"\[Pi]", "-", 
+         SubscriptBox["\[Theta]", "1"]}], "2"], "+", 
+       RowBox[{"ArcCos", "[", 
+        RowBox[{
+         FractionBox[
+          SubscriptBox["r", "2"], 
+          RowBox[{"2", 
+           SubscriptBox["r", "1"]}]], 
+         SqrtBox[
+          RowBox[{"2", "[", 
+           RowBox[{"1", "-", 
+            RowBox[{"Cos", "[", 
+             SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
+      " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+    "\[IndentingNewLine]", "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
+      RowBox[{"2", 
+       RowBox[{"ArcSin", "[", 
+        RowBox[{
+         FractionBox[
+          SubscriptBox["r", "2"], 
+          RowBox[{"2", 
+           SubscriptBox["r", "1"]}]], 
+         SqrtBox[
+          RowBox[{"2", "[", 
+           RowBox[{"1", "-", 
+            RowBox[{"Cos", "[", 
+             SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]]}], "]"}]}], ",", 
+      " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}]}], 
+   "\[IndentingNewLine]", "*)"}], "\[IndentingNewLine]", 
+  "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+  "\[IndentingNewLine]", "\[IndentingNewLine]", 
+  RowBox[{"(*", 
+   RowBox[{
+    RowBox[{"Formulas", " ", "for", " ", "C3H"}], ",", " ", 
     RowBox[{
-     RowBox[{"FullSimplify", "[", 
+    "All", " ", "of", " ", "these", " ", "can", " ", "be", " ", 
+     "simplified"}]}], "*)"}], "\[IndentingNewLine]", 
+  RowBox[{"(*", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       SqrtBox[
        RowBox[{
         SuperscriptBox[
@@ -113,9 +148,19 @@ Cell[BoxData[
             FractionBox[
              SubscriptBox["r", "1"], 
              RowBox[{"2", 
-              SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+              SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]], ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+    "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{"ArcCos", "[", 
        FractionBox[
         SubscriptBox["r", "1"], 
@@ -137,8 +182,19 @@ Cell[BoxData[
                 SubscriptBox["r", "1"], 
                 RowBox[{"2", 
                  SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-      "]"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+      ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+    "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{
        RowBox[{"ArcCos", "[", 
         FractionBox[
@@ -166,9 +222,19 @@ Cell[BoxData[
         FractionBox[
          SubscriptBox["r", "1"], 
          RowBox[{"2", 
-          SubscriptBox["r", "2"]}]], "]"}]}], "]"}], "\[IndentingNewLine]", 
-     "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+          SubscriptBox["r", "2"]}]], "]"}]}], ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}], "\[IndentingNewLine]", 
+    "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{"ArcSin", "[", 
        FractionBox[
         SubscriptBox["r", "1"], 
@@ -190,16 +256,28 @@ Cell[BoxData[
                 SubscriptBox["r", "1"], 
                 RowBox[{"2", 
                  SubscriptBox["r", "2"]}]], "]"}]}], "]"}]}]}]]}]], "]"}], 
-      "]"}]}], "*)"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{"(*", 
-    RowBox[{
-     RowBox[{"Formulas", " ", "for", " ", "S2H2"}], ",", " ", 
-     RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
-   "\[IndentingNewLine]", "\[IndentingNewLine]", 
-   RowBox[{"(*", 
-    RowBox[{
-     RowBox[{"FullSimplify", "[", 
+      ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "3"], ">", "0"}]}]}], "]"}]}], 
+   "\[IndentingNewLine]", "*)"}], "\[IndentingNewLine]", 
+  "\[IndentingNewLine]", "\[IndentingNewLine]", "\[IndentingNewLine]", 
+  "\[IndentingNewLine]", 
+  RowBox[{"(*", 
+   RowBox[{
+    RowBox[{"Formulas", " ", "for", " ", "S2H2"}], ",", " ", 
+    RowBox[{"no", " ", "simplification", " ", "found"}]}], "*)"}], 
+  "\[IndentingNewLine]", 
+  RowBox[{"(*", "\[IndentingNewLine]", 
+   RowBox[{
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{"ArcCos", "[", 
        RowBox[{
         SubscriptBox["r", "1"], 
@@ -218,9 +296,20 @@ Cell[BoxData[
              SubscriptBox["r", "1"], 
              SubscriptBox["r", "2"], 
              RowBox[{"Cos", "[", 
-              SubscriptBox["\[Theta]", "2"], "]"}]}]}], "]"}]]]}], "]"}], 
-      "]"}], "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+              SubscriptBox["\[Theta]", "2"], "]"}]}]}], "]"}]]]}], "]"}], ",",
+       " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "1"], ">", "0"}]}]}], "]"}], 
+    "\[IndentingNewLine]", "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{"ArcCos", "[", 
        FractionBox[
         RowBox[{
@@ -239,9 +328,19 @@ Cell[BoxData[
            SubscriptBox["r", "1"], 
            SubscriptBox["r", "2"], 
            RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+    "\[IndentingNewLine]", "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{"ArcCos", "[", 
        FractionBox[
         RowBox[{
@@ -260,24 +359,39 @@ Cell[BoxData[
            SubscriptBox["r", "1"], 
            SubscriptBox["r", "2"], 
            RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+            SubscriptBox["\[Theta]", "2"], "]"}]}]}]]], "]"}], ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["r", "2"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+    "\[IndentingNewLine]", "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{"ArcCos", "[", 
        FractionBox[
         RowBox[{
          RowBox[{"Cos", "[", 
           SubscriptBox["\[Theta]", "1"], "]"}], "-", 
-         SuperscriptBox[
-          RowBox[{"[", 
-           RowBox[{"Cos", "[", 
-            SubscriptBox["\[Theta]", "2"], "]"}], "]"}], "2"]}], 
-        SuperscriptBox[
-         RowBox[{"[", 
-          RowBox[{"Sin", "[", 
-           SubscriptBox["\[Theta]", "2"], "]"}], "]"}], "2"]], "]"}], "]"}], 
-     "\[IndentingNewLine]", "\[IndentingNewLine]", 
-     RowBox[{"FullSimplify", "[", 
+         RowBox[{
+          SuperscriptBox["Cos", "2"], "[", 
+          SubscriptBox["\[Theta]", "2"], "]"}]}], 
+        RowBox[{
+         SuperscriptBox["Sin", "2"], "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}]], "]"}], ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}], 
+    "\[IndentingNewLine]", "\[IndentingNewLine]", 
+    RowBox[{"FullSimplify", "[", 
+     RowBox[{
       RowBox[{"ArcCos", "[", 
        FractionBox[
         RowBox[{
@@ -290,100 +404,130 @@ Cell[BoxData[
          RowBox[{"Sin", "[", 
           SubscriptBox["\[Theta]", "2"], "]"}], 
          RowBox[{"Sin", "[", 
-          SubscriptBox["\[Theta]", "1"], "]"}]}]], "]"}], "]"}]}], "*)"}], 
-   "\[IndentingNewLine]", "\[IndentingNewLine]"}]}]], "Input",
+          SubscriptBox["\[Theta]", "1"], "]"}]}]], "]"}], ",", " ", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "1"], ">", "0"}]}], ",", 
+      RowBox[{"Assumptions", "->", 
+       RowBox[{
+        SubscriptBox["\[Theta]", "2"], ">", "0"}]}]}], "]"}]}], 
+   "\[IndentingNewLine]", "*)"}], "\[IndentingNewLine]", 
+  "\[IndentingNewLine]"}]], "Input",
  CellChangeTimes->CompressedData["
-1:eJxTTMoPSmViYGAQAWIQfU2B92anwFtHtZLCWyD61nreJyD6mY3YWxDtIq79
-H0RzHbDh6wLSQac2i4Po7I/FNiA6JMLDAUR/mq0bCKI1Tr0MB9ECzxQiQXSD
-d0M+iF7sVVIEos+0/asG0euVtWpANOuhTY0gWiLauRlEV+WmtoPolgLP6SCa
-SfHQYhA9idFhCYhWedi4DkQ7VbOuB9EVxfe2guiaxzOOgehrutXnQPTHCKcr
-INpkQeczEN31dO8rED31EetXEH272u0biD538N0vEP1q8ac/IHpaXA1LN8g+
-QXUOEC13yIMfRHut2icIoqW2nnUH0QfWXPcH0QAVPZkE
+1:eJwVzUEoQwEAh/FZXi012y4bO2iLEO0iB2lqm8UzBxllUpK2i8XwdtB777A1
+WRsnvaFc1HOQxmrakeYlh8Vy0GSKMK+spvaKw1rY//D1O37GeZ/TI5fJZM21
+YM6gfIyoS9Z2/0oe5hPKAhTN2hK067r/YEPa3Bit6cyc6aC3TJnhpIu0QGnf
+NA47M59TUC0apmFgNOCDvMO/Cm82fhmYaO1iISEkg7BpZjAE6UVPGK4vj+xC
+uVHg4Xad5RC2vQZPoY0hEnCNek5B9n3vGuZMTBaWXbZ72HsQEWH047wIY2/E
+N3xihn5g9vKrAou8VIU7s2z9Jn6aDgVsEUgVdBxfaKA+dTsM0/GHMXgXJ920
+pmTlFKoFqO8bWIK094WCsQIXgm4tF4Y94skWtNP9PJQmqkfwqjKXhP+PBL5+
+
   "],ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
 
 Cell[BoxData[
- SqrtBox[
+ RowBox[{"ArcCos", "[", 
   RowBox[{
-   SubsuperscriptBox["r", "1", "2"], "+", 
-   RowBox[{"2", " ", 
-    RowBox[{"Cos", "[", 
-     RowBox[{
-      RowBox[{"ArcCsc", "[", 
-       FractionBox[
-        RowBox[{"2", " ", 
-         SubscriptBox["r", "1"]}], 
-        RowBox[{
-         SqrtBox[
-          RowBox[{"2", "[", 
-           RowBox[{"1", "-", 
-            RowBox[{"Cos", "[", 
-             SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]], " ", 
-         SubscriptBox["r", "2"]}]], "]"}], "+", 
-      FractionBox[
-       SubscriptBox["\[Theta]", "1"], "2"]}], "]"}], " ", 
-    SubscriptBox["r", "1"], " ", 
-    SubscriptBox["r", "2"]}], "+", 
-   SubsuperscriptBox["r", "2", "2"]}]]], "Output",
+   SqrtBox[
+    FractionBox[
+     RowBox[{"1", "-", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "1"], "]"}]}], 
+     RowBox[{"2", "[", 
+      RowBox[{
+       SubsuperscriptBox["r", "1", "2"], "-", 
+       RowBox[{"2", " ", 
+        RowBox[{"Cos", "[", 
+         SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+        SubscriptBox["r", "1"], " ", 
+        SubscriptBox["r", "2"]}], "+", 
+       SubsuperscriptBox["r", "2", "2"]}], "]"}]]], " ", 
+   SubscriptBox["r", "1"]}], "]"}]], "Output",
  CellChangeTimes->{
-  3.900985461917469*^9, 3.900985658707184*^9, {3.9009858140825872`*^9, 
-   3.900985864651655*^9}, {3.900985979471822*^9, 3.900985995188621*^9}, 
-   3.900986053646082*^9, {3.900986429279138*^9, 3.9009864511251163`*^9}, {
-   3.9009865454766073`*^9, 3.900986555540372*^9}, 3.900986659550846*^9, 
-   3.900986950989963*^9, {3.900987018449424*^9, 3.900987043640712*^9}, 
-   3.9009872247771053`*^9, {3.90098730665539*^9, 3.900987315589512*^9}, 
-   3.900987521081943*^9},
- CellLabel->
-  "Out[113]=",ExpressionUUID->"e350fc95-73d6-48f1-bb3c-2f8fa9ab26b6"],
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.9014782397613564`*^9},
+ CellLabel->"Out[20]=",ExpressionUUID->"112898ba-4d92-4169-93e1-9eeb98b3e397"],
 
 Cell[BoxData[
- RowBox[{"\[Pi]", "-", 
-  RowBox[{"ArcCsc", "[", 
-   FractionBox[
-    RowBox[{"2", " ", 
-     SubscriptBox["r", "1"]}], 
-    RowBox[{
-     SqrtBox[
-      RowBox[{"2", "[", 
-       RowBox[{"1", "-", 
-        RowBox[{"Cos", "[", 
-         SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]], " ", 
-     SubscriptBox["r", "2"]}]], "]"}], "-", 
+ RowBox[{"ArcCos", "[", 
   FractionBox[
-   SubscriptBox["\[Theta]", "1"], "2"]}]], "Output",
+   RowBox[{
+    SubscriptBox["r", "1"], "-", 
+    RowBox[{
+     RowBox[{"Cos", "[", 
+      SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+     SubscriptBox["r", "2"]}]}], 
+   SqrtBox[
+    RowBox[{
+     SubsuperscriptBox["r", "1", "2"], "-", 
+     RowBox[{"2", " ", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+      SubscriptBox["r", "1"], " ", 
+      SubscriptBox["r", "2"]}], "+", 
+     SubsuperscriptBox["r", "2", "2"]}]]], "]"}]], "Output",
  CellChangeTimes->{
-  3.900985461917469*^9, 3.900985658707184*^9, {3.9009858140825872`*^9, 
-   3.900985864651655*^9}, {3.900985979471822*^9, 3.900985995188621*^9}, 
-   3.900986053646082*^9, {3.900986429279138*^9, 3.9009864511251163`*^9}, {
-   3.9009865454766073`*^9, 3.900986555540372*^9}, 3.900986659550846*^9, 
-   3.900986950989963*^9, {3.900987018449424*^9, 3.900987043640712*^9}, 
-   3.9009872247771053`*^9, {3.90098730665539*^9, 3.900987315589512*^9}, 
-   3.9009875210826406`*^9},
- CellLabel->
-  "Out[114]=",ExpressionUUID->"e7f6152c-0f6b-43f8-95e4-e2542f472260"],
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.901478239782833*^9},
+ CellLabel->"Out[21]=",ExpressionUUID->"eceefdfc-656c-4af4-b07e-5432c020b547"],
 
 Cell[BoxData[
- RowBox[{"2", " ", 
-  RowBox[{"ArcCsc", "[", 
-   FractionBox[
-    RowBox[{"2", " ", 
-     SubscriptBox["r", "1"]}], 
+ RowBox[{"ArcCos", "[", 
+  FractionBox[
+   RowBox[{
     RowBox[{
-     SqrtBox[
-      RowBox[{"2", "[", 
-       RowBox[{"1", "-", 
-        RowBox[{"Cos", "[", 
-         SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]], " ", 
-     SubscriptBox["r", "2"]}]], "]"}]}]], "Output",
+     RowBox[{"-", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "2"], "]"}]}], " ", 
+     SubscriptBox["r", "1"]}], "+", 
+    SubscriptBox["r", "2"]}], 
+   SqrtBox[
+    RowBox[{
+     SubsuperscriptBox["r", "1", "2"], "-", 
+     RowBox[{"2", " ", 
+      RowBox[{"Cos", "[", 
+       SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+      SubscriptBox["r", "1"], " ", 
+      SubscriptBox["r", "2"]}], "+", 
+     SubsuperscriptBox["r", "2", "2"]}]]], "]"}]], "Output",
  CellChangeTimes->{
-  3.900985461917469*^9, 3.900985658707184*^9, {3.9009858140825872`*^9, 
-   3.900985864651655*^9}, {3.900985979471822*^9, 3.900985995188621*^9}, 
-   3.900986053646082*^9, {3.900986429279138*^9, 3.9009864511251163`*^9}, {
-   3.9009865454766073`*^9, 3.900986555540372*^9}, 3.900986659550846*^9, 
-   3.900986950989963*^9, {3.900987018449424*^9, 3.900987043640712*^9}, 
-   3.9009872247771053`*^9, {3.90098730665539*^9, 3.900987315589512*^9}, 
-   3.900987521083208*^9},
- CellLabel->
-  "Out[115]=",ExpressionUUID->"3d3cc132-e25e-44d0-b90e-eb0576177e61"]
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.901478239783462*^9},
+ CellLabel->"Out[22]=",ExpressionUUID->"6cde4a8c-fe19-41f6-a4e7-f9a573e71526"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  FractionBox[
+   RowBox[{
+    RowBox[{"Cos", "[", 
+     SubscriptBox["\[Theta]", "1"], "]"}], "-", 
+    RowBox[{
+     SuperscriptBox["Cos", "2"], "[", 
+     SubscriptBox["\[Theta]", "2"], "]"}]}], 
+   RowBox[{
+    SuperscriptBox["Sin", "2"], "[", 
+    SubscriptBox["\[Theta]", "2"], "]"}]], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.901478239937957*^9},
+ CellLabel->"Out[23]=",ExpressionUUID->"33727f99-9839-441c-b2aa-2830b8e743f5"],
+
+Cell[BoxData[
+ RowBox[{"ArcCos", "[", 
+  RowBox[{
+   RowBox[{"Csc", "[", 
+    SubscriptBox["\[Theta]", "1"], "]"}], " ", 
+   RowBox[{"Csc", "[", 
+    SubscriptBox["\[Theta]", "2"], "]"}], " ", 
+   RowBox[{
+    RowBox[{"Cos", "[", 
+     SubscriptBox["\[Theta]", "2"], "]"}], "[", 
+    RowBox[{"1", "-", 
+     RowBox[{"Cos", "[", 
+      SubscriptBox["\[Theta]", "1"], "]"}]}], "]"}]}], "]"}]], "Output",
+ CellChangeTimes->{
+  3.9014777929903183`*^9, {3.901477921801724*^9, 3.901477951505554*^9}, 
+   3.901478039466735*^9, 3.9014781733337803`*^9, 3.90147824009628*^9},
+ CellLabel->"Out[24]=",ExpressionUUID->"b2781ddb-056d-4e5a-8430-240d1e0ab1e7"]
 }, Open  ]]
 },
 WindowSize->{Full, Full},
@@ -405,10 +549,12 @@ CellTagsIndex->{}
 (*NotebookFileOutline
 Notebook[{
 Cell[CellGroupData[{
-Cell[580, 22, 9738, 279, 1049, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
-Cell[10321, 303, 1260, 32, 60, "Output",ExpressionUUID->"e350fc95-73d6-48f1-bb3c-2f8fa9ab26b6"],
-Cell[11584, 337, 986, 24, 56, "Output",ExpressionUUID->"e7f6152c-0f6b-43f8-95e4-e2542f472260"],
-Cell[12573, 363, 919, 22, 56, "Output",ExpressionUUID->"3d3cc132-e25e-44d0-b90e-eb0576177e61"]
+Cell[580, 22, 13864, 402, 1120, "Input",ExpressionUUID->"04cede38-f319-4cec-a380-f6c25a57757c"],
+Cell[14447, 426, 800, 21, 64, "Output",ExpressionUUID->"112898ba-4d92-4169-93e1-9eeb98b3e397"],
+Cell[15250, 449, 773, 21, 58, "Output",ExpressionUUID->"eceefdfc-656c-4af4-b07e-5432c020b547"],
+Cell[16026, 472, 796, 22, 58, "Output",ExpressionUUID->"6cde4a8c-fe19-41f6-a4e7-f9a573e71526"],
+Cell[16825, 496, 592, 15, 57, "Output",ExpressionUUID->"33727f99-9839-441c-b2aa-2830b8e743f5"],
+Cell[17420, 513, 644, 16, 34, "Output",ExpressionUUID->"b2781ddb-056d-4e5a-8430-240d1e0ab1e7"]
 }, Open  ]]
 }
 ]


### PR DESCRIPTION
Hi Nike, I've updated the files with the restriction that all the bond angles and bond lengths must be positive, however I did not seem to get any simplified result that I haven't encountered before. Maybe I'm doing something wrong, and someone more experienced can improve upon these files?

The previous version only had 3 outputs because I commented out the rest of the code (I didn't want previous simplifications to keep outputting as I'm working with other equations). Each block has a "(*" and a corresponding "*)" at the beginning and the end, removing those will cause the simplified equations of that block to be shown in the output.